### PR TITLE
[Rails/UnknownEnv回避] Add custom environment definition

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -201,3 +201,11 @@ ParameterLists:
 Metrics/ClassLength:
   Exclude:
     - "test/**/*.rb"
+
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - staging
+    - development
+    - local
+    - test

--- a/lib/fablicop/version.rb
+++ b/lib/fablicop/version.rb
@@ -1,3 +1,3 @@
 module Fablicop
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/issues/4956

# 背景
localはRailsデフォルトの環境ではなく'、 Rails/UnknownEnv: Unknown environment `local?` のようなエラーがでる

# 目的
Frilアプリケーションで有効な環境を明示的に宣言する

# 結果
localが適切な環境だと認識されエラーが出なくなる

元issueによると、Railsデフォルトの環境も明示的に宣言する必要がある