### PR TITLE
specとtestのfixturesを除外する

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -6,7 +6,9 @@ AllCops:
     - "db/migrate/*"
     - "db/fixtures/**/*"
     - "test/factories/**/*"
+    - "test/fixtures/**/*"
     - "spec/factories/**/*"
+    - "spec/fixtures/**/*"
     - "spec/test_app/db/*"
 
   DisplayCopNames: true

--- a/lib/fablicop/version.rb
+++ b/lib/fablicop/version.rb
@@ -1,3 +1,3 @@
 module Fablicop
-  VERSION = '1.0.6'
+  VERSION = '1.0.7'
 end


### PR DESCRIPTION
specとtestのfixturesにはほぼ画像やyml、XMLしか配置されていないためRubocopの対象から除外する。