### PR TITLE
重複している指定を削除

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -149,10 +149,6 @@ Layout/SpaceInLambdaLiteral:
   Enabled: false
 Layout/IndentHeredoc:
   Enabled: false
-Layout/MultilineMethodCallBraceLayout:
-  Enabled: false
-Layout/MultilineMethodCallIndentation:
-  Enabled: false
 
 ##################### Lint ##################################
 
@@ -193,10 +189,6 @@ Metrics/AbcSize:
   Max: 15
   Exclude:
     - "test/**/*.rb"
-
-# キーワード引数は引数の数に含めない
-ParameterLists:
-  CountKeywordArgs: false
 
 Metrics/ClassLength:
   Exclude:


### PR DESCRIPTION
以下の指定が被ってるので削除しました。

1. 79~80行目 `Layout/MultilineMethodCallBraceLayout`
```
...
Layout/MultilineMethodCallBraceLayout:
  Enabled: false
...
```
2. 97~98行目 `Layout/MultilineMethodCallIndentation`
```
...
Layout/MultilineMethodCallIndentation:
  Enabled: false
...
```
3. 179~181行目 `ParameterLists`
```
...
# キーワード引数は引数の数に含めない
ParameterLists:
  CountKeywordArgs: false
...
```