### PR TITLE
add stg_qa01 to rubocop environments list

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -201,6 +201,7 @@ Rails/UnknownEnv:
     - development
     - local
     - test
+    - stg_qa01
 
 Gemspec/OrderedDependencies:
   Enabled: false


### PR DESCRIPTION
## 問題
- fril_webに二重定義されて、base_rubocop.ymlの環境変数が消えた。詳細はissue見て： https://github.com/Fablic/fril_web/issues/8340

## 修正点
- SSIA