### PR TITLE
Remove TargetRubyVersion from template

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -13,7 +13,6 @@ AllCops:
     - "spec/test_app/db/*"
 
   DisplayCopNames: true
-  TargetRubyVersion: 2.5
   NewCops: enable # 新しい規約も随時取り入れる
 Rails:
   Enabled: true

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -5,6 +5,3 @@ inherit_gem:
     # - "config/rails.yml"
     # uncomment if use rspec cops
     # - "config/rspec.yml"
-
-AllCops:
-  TargetRubyVersion: 2.3


### PR DESCRIPTION
closes #36 

Rails 6.1で動作確認済み

### 動作確認

rails 6.1のリポジトリに導入し動作確認

```shell
$ bundle exec fablicop init
overwrite .rubocop.yml

$ bundle exec rubocop app/controllers/application_controller.rb
Inspecting 1 file
C

Offenses:

app/controllers/application_controller.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
class ApplicationController < ActionController::Base
^

1 file inspected, 1 offense detected, 1 offense auto-correctable
```