### PR TITLE
rubocopの変更に合わせて規約名をリネーム、規約を削除

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -93,9 +93,6 @@ Style/DoubleNegation:
 Style/ParallelAssignment:
   Enabled: false
 
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 Style/MethodCallWithoutArgsParentheses:
   Enabled: false
 
@@ -135,7 +132,7 @@ Layout/SpaceBeforeFirstArg:
   Enabled: false
 Layout/SpaceInLambdaLiteral:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 # 引数の書き方の多様性を許可
@@ -196,7 +193,7 @@ Layout/DotPosition:
 Layout/ClosingParenthesisIndentation:
   Exclude:
     - "db/fixtures/*.rb"
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Exclude:
     - "db/fixtures/*.rb"
 

--- a/lib/fablicop/version.rb
+++ b/lib/fablicop/version.rb
@@ -1,3 +1,3 @@
 module Fablicop
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
 end


### PR DESCRIPTION
fablicop 1.0.8 で実行しようとしたところ、以下エラーが出たため、この対応を行うもの

```
Error: The `Layout/AlignParameters` cop has been renamed to `Layout/ParameterAlignment`.
(obsolete configuration found in vendor/bundle/ruby/2.5.0/gems/fablicop-1.0.8/config/.base_rubocop.yml, please update it)
The `Layout/IndentHeredoc` cop has been renamed to `Layout/HeredocIndentation`.
(obsolete configuration found in vendor/bundle/ruby/2.5.0/gems/fablicop-1.0.8/config/.base_rubocop.yml, please update it)
The `Style/BracesAroundHashParameters` cop has been removed. Please use  and/or  instead.
(obsolete configuration found in vendor/bundle/ruby/2.5.0/gems/fablicop-1.0.8/config/.base_rubocop.yml, please update it)
```