### PR TITLE
Disable Naming/RescuedExceptionsVariableName

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -223,3 +223,8 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Exclude:
     - "test/**/*.rb"
+
+# Does the variable name for an exception object really matter?
+# There are many things to think about before taking care of it.
+Naming/RescuedExceptionsVariableName:
+  Enabled: false


### PR DESCRIPTION
In my opinion, the variable name for an exception is not important in many cases. Some love to name it as `e`, some like `error`, some insist on naming it as `exception`... I believe it absolutely a matter of preference and does not undermine productivity in software development. Besides, even if someone writes code with so an inappropriate variable, this would be pointed out by other code reviewers.

So, I want to disable `Naming/RescuedExceptionsVariableName`.
