### PR TITLE
Fix the config path for fablicop and replace `inherit_gem` with `inherit_from`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,2 @@
 inherit_gem:
-  fablicop: "config/base_rubocop.yml"
+  fablicop: "config/.base_rubocop.yml"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,1 @@
-inherit_gem:
-  fablicop: "config/.base_rubocop.yml"
+inherit_from: config/.base_rubocop.yml


### PR DESCRIPTION
I found out the config path declared as `inherit_gem` is wrong.
This should indicate `config/.base_rubocop.yml`.