### PR TITLE
Remove unnecessary comments from the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,45 @@
 # fablicop
 
 fablicop is a RuboCop configration gem.
+It assumes your project is using Ruby on Rails, so some Cops prefixed with `Rails` are enabled out of the box.
+In other words, it's not appropriate to use it with non-Rails projects.
 
-## Usage
+## Installation
 
-Setup .rubocop.yml
+You can install fablicop with this command:
 
-```sh
-bundle exec fablicop init
+```console
+gem install fablicop
 ```
 
-`init` generate the following directive to your `.rubocop.yml`:
+Or, run `bundle install` after adding this line to your application's Gemfile:
+
+```ruby
+gem 'fablicop', require: false
+```
+
+## Getting started
+
+Set up `.rubocop.yml` with the command below.
+
+```console
+fablicop init
+```
+
+`init` generates the following directive to your `.rubocop.yml`:
 
 ```yaml
 inherit_gem:
   fablicop:
     - "config/.base_rubocop.yml"
-    # uncomment if use rails cops
-    # - "config/rails.yml"
-    # uncomment if use rspec cops
-    # - "config/rspec.yml"
 ```
 
-```sh
-bundle exec rubocop <options...>
-```
+## Usage
 
-## Installation
+After configuration, your RuboCop now sees fablicop's configuration. Just run `rubocop` as usual.
 
-Add this line to your application's Gemfile:
-
-```ruby
-group :development do
-  gem "fablicop", require: false
-end
+```console
+bundle exec rubocop
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ inherit_gem:
 After configuration, your RuboCop now sees fablicop's configuration. Just run `rubocop` as usual.
 
 ```console
+rubocop
+```
+
+Or, prefix `bundle exec`.
+
+```console
 bundle exec rubocop
 ```
 

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -1,7 +1,3 @@
 inherit_gem:
   fablicop:
     - "config/.base_rubocop.yml"
-    # uncomment if use rails cops
-    # - "config/rails.yml"
-    # uncomment if use rspec cops
-    # - "config/rspec.yml"


### PR DESCRIPTION
fablicop now has neither `config/rails.yml` nor `config/rspec.yml`. I
removed these files from the template. Also, I updated README.md to
follow this change while changing its section orders.