### PR TITLE
Enable rubocop-rspec

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-rails
+  - rubocop-rspec
 
 # We exclude files that are generated automatically or test data.
 AllCops:


### PR DESCRIPTION
I found out rubocop-rspec is not listed in `require` 😇