### PR TITLE
Disable Style/IfUnlessModifier

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -101,6 +101,10 @@ Style/NumericLiterals:
   Exclude:
     - "db/fixtures/*.rb"
 
+# This is the matter of preference.
+Style/IfUnlessModifier:
+  Enabled: false
+
 ##################### Layout ##################################
 # We sometimes want to put multiple spaces before arguments.
 Layout/SpaceBeforeFirstArg:


### PR DESCRIPTION
It's OK to write like this.

```ruby
x = true
a = if x
  :parameter
end
```