### PR TITLE
Set Max: 20 for Metrics/AbcSize

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -210,7 +210,10 @@ Metrics/BlockLength:
     - "app/admin/*.rb"
     - "config/**/*.rb"
 
+# We discussed internally about this parameter and decided to follow this configuration.
+# https://github.com/onk/onkcop/blob/8066859d3d00328146c1da9e57bdd4a951974ef2/config/rubocop.yml#L113-L116
 Metrics/AbcSize:
+  Max: 24
   Exclude:
     - "test/**/*.rb"
 

--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -213,7 +213,7 @@ Metrics/BlockLength:
 # We discussed internally about this parameter and decided to follow this configuration.
 # https://github.com/onk/onkcop/blob/8066859d3d00328146c1da9e57bdd4a951974ef2/config/rubocop.yml#L113-L116
 Metrics/AbcSize:
-  Max: 24
+  Max: 20
   Exclude:
     - "test/**/*.rb"
 


### PR DESCRIPTION
Perhaps, most of us are suffering from the default configuration of Metrics/AbcSize.
So, I want to alleviate the pain with the loosened value, following [onkcop](https://github.com/onk/onkcop/blob/8066859d3d00328146c1da9e57bdd4a951974ef2/config/rubocop.yml#L113-L116).