### PR TITLE
Disable RSpec/DescribedClass

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -247,3 +247,7 @@ RSpec/NamedSubject:
 # because response validation in `request spec` is expected to result in large rows
 RSpec/ExampleLength:
   Enabled: false
+
+# We don't care about whether using `described_class` or not.
+RSpec/DescribedClass:
+  Enabled: false


### PR DESCRIPTION
I don't want to enforce this cop because it would be a matter of
preference.