### PR TITLE
Disable Style/NumericPredicate

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -100,6 +100,10 @@ Style/ClassAndModuleChildren:
 Style/NumericLiterals:
   Enabled: false
 
+# foo.zero? don't care nil case, we should avoid undefined method risk
+Style/NumericPredicate:
+  Enabled: false
+
 # We don't care which we use: #yield_self or #then
 Style/ObjectThen:
   Enabled: false


### PR DESCRIPTION
Close #79 

issue
https://github.com/Fablic/fablicop/pull/new/disable_numeric_predicate

`Style/NumericPredicate`
foo.zero? don't care nil case, we should avoid undefined method risk
when run `rubocop -A`, foo == 0 replace foo.zero? `zero?` will error if foo is nil