### PR TITLE
Disable Naming/VariableNumber

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -236,6 +236,9 @@ Metrics/PerceivedComplexity:
 Naming/RescuedExceptionsVariableName:
   Enabled: false
 
+Naming/VariableNumber:
+  Enabled: false
+
 ##################### RSpec ##################################
 
 # disabling to not to show errors if there is no when/with/without in the context


### PR DESCRIPTION
Sometimes, we want to name variables with numbers. If the naming is important, this should be reviewed by humans.