### PR TITLE
Disable Style/WordArray

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -116,6 +116,10 @@ Style/FetchEnvVar:
 Style/IfUnlessModifier:
   Enabled: false
 
+# We don't care about the style of Arrays.
+Style/WordArray:
+  Enabled: false
+
 ##################### Layout ##################################
 # We sometimes want to put multiple spaces before arguments.
 Layout/SpaceBeforeFirstArg:


### PR DESCRIPTION
I don't think `Style/WordArray` is useful in our application. In some cases, `%w` might be useful, but it sometimes causes problems.

For example, `%w[true false]` is the same as `["true", "false"]`, not `[true, false]`. In this case, I think `["true", "false"]` might be better.

So, I don't want to enforce this rule in a whole project.