### PR TITLE
add HashAlignment

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -39,6 +39,10 @@ Gemspec/OrderedDependencies:
 
 ##################### Style ##################################
 
+# We like to keep the hash key and value left.
+AlignHash:
+  EnforcedColonStyle: table
+
 # We sometimes use non-ascii comments.
 Style/AsciiComments:
   Enabled: false

--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -41,6 +41,7 @@ Gemspec/OrderedDependencies:
 
 # We like to keep the hash key and value left.
 HashAlignment:
+  EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
 # We sometimes use non-ascii comments.

--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -40,7 +40,7 @@ Gemspec/OrderedDependencies:
 ##################### Style ##################################
 
 # We like to keep the hash key and value left.
-AlignHash:
+HashAlignment:
   EnforcedColonStyle: table
 
 # We sometimes use non-ascii comments.


### PR DESCRIPTION
# Suggestion
Wouldn't it be better to align the keys and values of ruby's hash to the left for better readability? ?

1.`EnforcedHashRocketStyle: table`
```ruby
# bad
{
  :foo => bar,
  :ba => baz
}

# good
{
  :foo => bar,
  :ba  => baz
}
```

2.`EnforcedColonStyle: table`

```ruby
# bad
{
  foo: bar,
  ba: baz
}

# good
{
  foo: bar,
  ba:  baz
}
```

# Reference
https://docs.rubocop.org/rubocop/cops_layout.html#layouthashalignment