### PR TITLE
Disable `Rails/HttpStatus`

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -23,6 +23,9 @@ Rails:
 Rails/HttpPositionalArguments:
   Enabled: false
 
+Rails/HttpStatus:
+  Enabled: false
+
 Rails/InverseOf:
   Enabled: false
 


### PR DESCRIPTION
I want to allow both symbolic and numeric with HTTP status.

https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailshttpstatus