### PR TITLE
Enabled Style::BlockDelimiters

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -70,9 +70,9 @@ Style/RedundantSelf:
 #     f x
 #     f x
 #   }.compact
-# do .. end から更にメソッドチェーンすると見づらいので
-# auto-correct せず、自分で修正する
-# spec 内は見た目が綺麗になるので許可
+# do ... . end, and further method chaining from the end would be confusing to look at, so
+# Do not auto-correct, fix it by yourself.
+# Allow it in specs because it looks nice.
 Style/BlockDelimiters:
   AutoCorrect: false
   Exclude:

--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -71,7 +71,7 @@ Style/RedundantSelf:
 #     f x
 #   }.compact
 # do ... . end, and further method chaining from the end would be confusing to look at
-# Do not auto-correct, fix it by yourself.
+# Don't use method chaining in auto-correct, and modify it yourself.
 # Allow it in specs because it looks nice.
 Style/BlockDelimiters:
   AutoCorrect: false

--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -70,7 +70,7 @@ Style/RedundantSelf:
 #     f x
 #     f x
 #   }.compact
-# do ... . end, and further method chaining from the end would be confusing to look at, so
+# do ... . end, and further method chaining from the end would be confusing to look at
 # Do not auto-correct, fix it by yourself.
 # Allow it in specs because it looks nice.
 Style/BlockDelimiters:

--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -70,8 +70,13 @@ Style/RedundantSelf:
 #     f x
 #     f x
 #   }.compact
+# do .. end から更にメソッドチェーンすると見づらいので
+# auto-correct せず、自分で修正する
+# spec 内は見た目が綺麗になるので許可
 Style/BlockDelimiters:
-  Enabled: false
+  AutoCorrect: false
+  Exclude:
+    - "spec/**/*"
 Style/MultilineBlockChain:
   Enabled: false
 Style/EmptyMethod:


### PR DESCRIPTION
I think Style::BlockDelimiters should be enabled and Autocorrect should be disabled

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BlockDelimiters