### PR TITLE
Disable Style/ClassAndModuleChildren

### DIFF
--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -100,7 +100,7 @@ Style/DefWithParentheses:
 
 # This might not be a style cop because errors happen due to the order of tests with nested classes/modules.
 Style/ClassAndModuleChildren:
-Enabled: false
+  Enabled: false
 
 # Sometimes, 1000 is better than 1_000. Especially, it's useful to run grep(1) for searching `1000`.
 Style/NumericLiterals:

--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -98,7 +98,9 @@ Style/MethodCallWithoutArgsParentheses:
 Style/DefWithParentheses:
   Enabled: false
 
-# This might not be a style cop because errors happen due to the order of tests with nested classes/modules.
+# fablicop assumes the application is built with Ruby on Rails, which regards the directories as namespaces.
+# Thus, we don't care our constants are defined in compact/nested style.
+# @see https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#project-structure
 Style/ClassAndModuleChildren:
   Enabled: false
 

--- a/config/.base_rubocop.yml
+++ b/config/.base_rubocop.yml
@@ -100,9 +100,7 @@ Style/DefWithParentheses:
 
 # This might not be a style cop because errors happen due to the order of tests with nested classes/modules.
 Style/ClassAndModuleChildren:
-  Exclude:
-    - "test/**/*.rb"
-    - "spec/**/*.rb"
+Enabled: false
 
 # Sometimes, 1000 is better than 1_000. Especially, it's useful to run grep(1) for searching `1000`.
 Style/NumericLiterals:


### PR DESCRIPTION
In nested syntax, if the class does not exist, it is newly defined. In other words, if the class exists, it is referenced; if it does not, it is defined.
In compact syntax, if the namespace is defined, it is referenced; if not, an exception is raised.
However, in a Rails application, the filename must match a defined constant, and the directory acts as the namespace, which is different behavior from ruby. Therefore, using compact syntax should not be a problem, and also, rubocop is a gem for rails, so we want to set `Style/ClassAndModuleChildren` to disable.

reference: https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#project-structure

**Merge Only**