### PR TITLE
Run CIs with Ruby 3.1 and 3.2

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
run-ci.yml should run tests with the currently supported Ruby. I added `"3.1"` and `"3.2"` to `jobs.strategy.matrix.ruby` for the purpose.