### PR TITLE
change private repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - run: git diff
 
-      - uses: yykamei/actions-git-push@main
+      - uses: Fablic/actions-git-push@main
         with:
           commit-message: Bump to ${{ github.event.inputs.version }}
         if: github.event.inputs.apply == 'true'
@@ -52,7 +52,7 @@ jobs:
           GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
         if: github.event.inputs.apply == 'true'
 
-      - uses: yykamei/actions-release-actions@main
+      - uses: Fablic/actions-release-actions@main
         with:
           tag: v${{ github.event.inputs.version }}
           apply: ${{ github.event.inputs.apply }}


### PR DESCRIPTION
https://github.com/Fablic/fril_webview/pull/6710

I was using GitHub Actions for my personal account, so I switched

https://github.com/yykamei/actions-git-push → https://github.com/Fablic/actions-git-push

https://github.com/yykamei/actions-release-actions → https://github.com/Fablic/actions-release-actions